### PR TITLE
Update ghostwriter/coding-standard to version dev-main#8a250f3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -639,12 +639,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "e0136bdf1ebe97475fd87da2572444ff84d7eedf"
+                "reference": "8a250f3d89117560553b0658401d6cc6c1bb58a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/e0136bdf1ebe97475fd87da2572444ff84d7eedf",
-                "reference": "e0136bdf1ebe97475fd87da2572444ff84d7eedf",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/8a250f3d89117560553b0658401d6cc6c1bb58a9",
+                "reference": "8a250f3d89117560553b0658401d6cc6c1bb58a9",
                 "shasum": ""
             },
             "require": {
@@ -819,7 +819,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-28T11:20:05+00:00"
+            "time": "2026-01-28T17:17:54+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#e0136bd` to `dev-main#8a250f3`.

This pull request changes the following file(s): 

- Update `composer.lock`